### PR TITLE
Delete posts

### DIFF
--- a/assets/js/Post.jsx
+++ b/assets/js/Post.jsx
@@ -38,12 +38,22 @@ class Post extends React.Component {
     api.create_new_reply(this.props.session.user_id, this.post_id, content, this.fetchPost.bind(this));
   }
 
+  deleteReply(id) {
+    api.delete_reply(id, this.fetchPost.bind(this));
+  }
+
   render() {
-    let replies = _.reverse(_.map(this.state.data.replies, (r) => (
-      <div key={r.id}>
+    let replies = _.reverse(_.map(this.state.data.replies, (r) => {
+      let deleteButton;
+      if (this.props.session && this.props.session.user_id == r.user_id) {
+        deleteButton = <button className="btn btn-danger" onClick={() => this.deleteReply(r.id)}>delete</button>
+      }
+
+      return <div key={r.id}>
         <b>{r.username}</b>: {r.content}
+        {deleteButton}
       </div>
-    ))); 
+    })); 
    
     let createReply; 
     if (this.props.session) {

--- a/assets/js/UserProfile.jsx
+++ b/assets/js/UserProfile.jsx
@@ -66,13 +66,14 @@ class UserProfile extends React.Component {
           <input placeholder="What's on my mind..." value={this.state.new_post_content} onChange={(ev) => this.updateState({new_post_content: ev.target.value})} /> 
           <button className="btn btn-primary" onClick={this.createNewPost.bind(this)}>Post</button>
         </span>;
+
     }
 
     return <div>
         <h2>{this.state.display_name}</h2>
         {friendStatus}
         {createPost}
-        <WallPosts posts={this.state.posts} /> 
+        <WallPosts session={this.props.session} posts={this.state.posts} deleteCallback={this.fetchUser.bind(this)} /> 
       </div>;
   }
     

--- a/assets/js/WallPosts.jsx
+++ b/assets/js/WallPosts.jsx
@@ -1,17 +1,28 @@
 import React from 'react';
 import _ from 'lodash';
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router-dom';
+
+import api from './api';
 
 function WallPosts(props) {
-  let {posts} = props;
+  let {posts, session, deleteCallback} = props;
+
+  let onDelete = (id) => {
+    api.delete_post(id, deleteCallback);
+  };
 
   // TODO add hyperlinks for posts
-  let allPosts = _.map(posts, (p) => (
-    <div key={p.id}>
+  let allPosts = _.map(posts, (p) => {
+    let deleteButton;
+      if (session && session.user_id == p.user_id) {
+        deleteButton = <button className="btn btn-danger" onClick={() => onDelete(p.id)}>delete</button>
+      }
+    return <div key={p.id}>
       <hr />
       <Link to={"/posts/" + p.id}>{p.content}</Link>
+      {deleteButton}
     </div>
-  ));
+  });
 
   return <div>
       {allPosts}

--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -86,6 +86,39 @@ class TheServer {
     });
   }
 
+  delete_post(post_id, successCallback = (resp) => {}, errorCallback = (resp) => {}) {
+    $.ajax("/api/v1/posts/" + post_id, {
+      method: "delete",
+      dataType: "json",
+      contentType: "application/json; charset=UTF-8",
+      data: "",
+      success: (resp) => {
+        successCallback(resp);
+      },
+      error: (resp) => {
+        console.log("failed to delete post");
+        console.log(resp);
+        errorCallback(resp);
+      }, 
+    });
+  }
+  delete_reply(reply_id, successCallback = (resp) => {}, errorCallback = (resp) => {}) {
+    $.ajax("/api/v1/replies/" + reply_id, {
+      method: "delete",
+      dataType: "json",
+      contentType: "application/json; charset=UTF-8",
+      data: "",
+      success: (resp) => {
+        successCallback(resp);
+      },
+      error: (resp) => {
+        console.log("failed to delete reply");
+        console.log(resp);
+        errorCallback(resp);
+      }, 
+    });
+  }
+
   accept_friend_request(id, successCallback = (resp) => {}, errorCallback = (resp) => {}) {
     $.ajax("/api/v1/friendrequests/" + id, {
       method: "put",

--- a/lib/project2_web/views/post_view.ex
+++ b/lib/project2_web/views/post_view.ex
@@ -12,12 +12,13 @@ defmodule Project2Web.PostView do
 
   def render("post.json", %{post: post}) do
     replies = post.replies
-    |> Enum.map(fn reply -> %{content: reply.content, time: reply.time, username: reply.user.display_name} end)
+    |> Enum.map(fn reply -> %{id: reply.id, content: reply.content, time: reply.time, username: reply.user.display_name, user_id: reply.user_id} end)
 
     %{id: post.id,
       content: post.content,
       time: post.time,
       replies: replies,
-      username: post.user.display_name}
+      username: post.user.display_name,
+      user_id: post.user.id}
   end
 end

--- a/lib/project2_web/views/user_view.ex
+++ b/lib/project2_web/views/user_view.ex
@@ -15,7 +15,7 @@ defmodule Project2Web.UserView do
 
   def render("user.json", %{user: user, friend_info: friend_info}) do
     posts = user.posts
-    |> Enum.map(fn post -> %{id: post.id, content: post.content} end)
+    |> Enum.map(fn post -> %{id: post.id, content: post.content, user_id: post.user_id} end)
    
     %{id: user.id,
       email: user.email,

--- a/priv/repo/migrations/20190403191727_create_replies.exs
+++ b/priv/repo/migrations/20190403191727_create_replies.exs
@@ -6,7 +6,7 @@ defmodule Project2.Repo.Migrations.CreateReplies do
       add :content, :string, null: false
       add :time, :utc_datetime, null: false
       add :user_id, references(:users, on_delete: :nothing), null: false
-      add :post_id, references(:posts, on_delete: :nothing), null: false
+      add :post_id, references(:posts, on_delete: :delete_all), null: false
 
       timestamps()
     end


### PR DESCRIPTION
branched off of `create-posts`, so this also has the changes from https://github.com/abinader89/cs4550-project2/pull/7

a logged in user can delete their posts/replies
eg: logging in as `alice@example.com` and nav-ing to `/users/1` shows buttons to delete the posts but logging in as `bob@example.com` does not show the buttons, since those are not bob's posts. same for the replies under `/posts/1`